### PR TITLE
Use `MultipleTelemetry` for ForwardPushTest and LateralPushTest

### DIFF
--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -281,7 +281,7 @@ private fun avgPos(es: List<Encoder>) = es.sumOf { it.getPositionAndVelocity().p
 
 class ForwardPushTest(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
-        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
+        telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
         val view = dvf.make(hardwareMap)
 
         for (m in view.motors) {
@@ -440,7 +440,7 @@ fun lateralSum(view: DriveView): Double {
 
 class LateralPushTest(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
-        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
+        telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
         val view = dvf.make(hardwareMap)
 
         require(view.type == DriveType.MECANUM) {
@@ -476,7 +476,7 @@ class ManualFeedforwardTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     }
 
     override fun runOpMode() {
-        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
+        telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         val view = dvf.make(hardwareMap)
         val profile = TimeProfile(constantProfile(
@@ -560,7 +560,7 @@ class MecanumMotorDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() 
             "Only mecanum drives should run this op mode."
         }
 
-        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
+        telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         telemetry.addLine("Press play to begin the debugging op mode")
         telemetry.update()
@@ -636,7 +636,7 @@ class DeadWheelDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() {
             "Only run this op mode if you're using dead wheels."
         }
 
-        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
+        telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         waitForStart()
 

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -281,6 +281,7 @@ private fun avgPos(es: List<Encoder>) = es.sumOf { it.getPositionAndVelocity().p
 
 class ForwardPushTest(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
+        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
         val view = dvf.make(hardwareMap)
 
         for (m in view.motors) {
@@ -439,6 +440,7 @@ fun lateralSum(view: DriveView): Double {
 
 class LateralPushTest(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
+        val telemetry = MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().telemetry)
         val view = dvf.make(hardwareMap)
 
         require(view.type == DriveType.MECANUM) {


### PR DESCRIPTION
Hi,

The tuning OpModes ForwardPushTest and LateralPushTest aren't using a MultipleTelemetry instance, causing ticks travelled to only display on the DS. These changes make ticks travelled show up on the dashboard too.