### PR TITLE
OTOS Tuning OpModes

### DIFF
--- a/RoadRunner/build.gradle
+++ b/RoadRunner/build.gradle
@@ -79,6 +79,7 @@ repositories {
 
 dependencies {
     api "org.firstinspires.ftc:RobotCore:$min_sdk_version"
+    api "org.firstinspires.ftc:Hardware:$min_sdk_version"
 
     api "com.acmerobotics.roadrunner:core:$min_rr_version"
     api "com.acmerobotics.roadrunner:actions:$min_rr_version"

--- a/RoadRunner/build.gradle
+++ b/RoadRunner/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.min_sdk_version = "10.0.0"
     ext.min_rr_version = "1.0.1"
     ext.min_dash_version = "0.4.10"
-    ext.rr_ftc_version = "0.1.20"
+    ext.rr_ftc_version = "0.1.19"
 }
 
 plugins {

--- a/RoadRunner/build.gradle
+++ b/RoadRunner/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.min_sdk_version = "10.0.0"
     ext.min_rr_version = "1.0.1"
     ext.min_dash_version = "0.4.10"
-    ext.rr_ftc_version = "0.1.19"
+    ext.rr_ftc_version = "0.1.20"
 }
 
 plugins {

--- a/RoadRunner/build.gradle
+++ b/RoadRunner/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.min_sdk_version = "10.0.0"
     ext.min_rr_version = "1.0.1"
     ext.min_dash_version = "0.4.10"
-    ext.rr_ftc_version = "0.1.15"
+    ext.rr_ftc_version = "0.1.16"
 }
 
 plugins {

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/LazyImu.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/LazyImu.kt
@@ -1,5 +1,6 @@
 package com.acmerobotics.roadrunner.ftc
 
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot
 import com.qualcomm.robotcore.hardware.HardwareMap
 import com.qualcomm.robotcore.hardware.IMU
 import com.qualcomm.robotcore.hardware.ImuOrientationOnRobot
@@ -18,12 +19,27 @@ class ImuInitMessage(
 )
 
 class LazyImu @JvmOverloads constructor(
-        private val hardwareMap: HardwareMap,
-        private val name: String,
-        private val orientation: ImuOrientationOnRobot,
-        private val timeoutMs: Int = 500,
+    private val hardwareMap: HardwareMap,
+    private val name: String,
+    private val orientation: ImuOrientationOnRobot = RevHubOrientationOnRobot(
+        RevHubOrientationOnRobot.LogoFacingDirection.UP,
+        RevHubOrientationOnRobot.UsbFacingDirection.FORWARD
+    ),
+    private val timeoutMs: Int = 500,
 ) {
-    private var imu: IMU? = null
+    @JvmOverloads constructor(
+        hardwareMap: HardwareMap,
+        imu: IMU,
+        timeoutMs: Int = 500
+    ) : this(
+        hardwareMap,
+        imu.deviceName,
+        timeoutMs=timeoutMs)
+    {
+        this.imu = imu
+    }
+
+    var imu: IMU? = null
 
     fun get(): IMU {
         if (imu == null) {

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -53,9 +53,7 @@ class OTOSEncoderGroup(val view: OTOSView) : EncoderGroup {
 class OTOSIMU(val view: OTOSView) : LazyImu, IMU, HardwareDevice by view.otos {
     override fun initialize(p0: IMU.Parameters?) = view.otos.initialize()
 
-    override fun resetYaw() {
-        view.otos.calibrateImu()
-    }
+    override fun resetYaw() = fail()
 
     override fun getRobotYawPitchRollAngles(): YawPitchRollAngles {
         return YawPitchRollAngles(AngleUnit.RADIANS, view.pose.h, 0.0, 0.0, 0L)
@@ -65,17 +63,15 @@ class OTOSIMU(val view: OTOSView) : LazyImu, IMU, HardwareDevice by view.otos {
         p0: AxesReference?,
         p1: AxesOrder?,
         p2: AngleUnit?
-    ): Orientation {
-       throw NotImplementedError()
-    }
+    ): Orientation = fail()
 
-    override fun getRobotOrientationAsQuaternion(): Quaternion {
-        TODO("Not yet implemented")
-    }
+    override fun getRobotOrientationAsQuaternion(): Quaternion = fail()
 
     override fun getRobotAngularVelocity(p0: AngleUnit?): AngularVelocity {
         return AngularVelocity(AngleUnit.RADIANS, 0.0f, 0.0f, view.vel.h.toFloat(), 0L)
     }
 
-    override fun get() = this
+    override fun get() = this as IMU
+
+    private fun fail(): Nothing = throw NotImplementedError("Not Needed For Tuning")
 }

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -3,6 +3,15 @@ package com.acmerobotics.roadrunner.ftc
 import com.qualcomm.hardware.sparkfun.SparkFunOTOS
 import com.qualcomm.hardware.sparkfun.SparkFunOTOS.Pose2D
 import com.qualcomm.robotcore.hardware.DcMotorSimple
+import com.qualcomm.robotcore.hardware.HardwareDevice
+import com.qualcomm.robotcore.hardware.IMU
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
+import org.firstinspires.ftc.robotcore.external.navigation.AngularVelocity
+import org.firstinspires.ftc.robotcore.external.navigation.AxesOrder
+import org.firstinspires.ftc.robotcore.external.navigation.AxesReference
+import org.firstinspires.ftc.robotcore.external.navigation.Orientation
+import org.firstinspires.ftc.robotcore.external.navigation.Quaternion
+import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles
 
 enum class EncoderDirection {
     PARALLEL,
@@ -13,14 +22,42 @@ class OTOSEncoder(val otos: SparkFunOTOS, val ed: EncoderDirection) : Encoder {
     override var direction = DcMotorSimple.Direction.FORWARD
 
     override fun getPositionAndVelocity(): PositionVelocityPair {
-        val otosPose: Pose2D = Pose2D()
-        val otosVel: Pose2D = Pose2D()
+        val otosPose = Pose2D()
+        val otosVel = Pose2D()
         otos.getPosVelAcc(otosPose, otosVel, Pose2D())
 
         return when (ed) {
             EncoderDirection.PARALLEL -> PositionVelocityPair(otosPose.x.toInt(), otosVel.x.toInt(), otosPose.x.toInt(), otosVel.x.toInt())
             EncoderDirection.PERPENDICULAR -> PositionVelocityPair(otosPose.y.toInt(), otosVel.y.toInt(), otosPose.y.toInt(), otosVel.y.toInt())
         }
+    }
+}
+
+class OTOSIMU(val otos: SparkFunOTOS) : IMU, HardwareDevice by otos {
+    override fun initialize(p0: IMU.Parameters?) = otos.initialize()
+
+    override fun resetYaw() {
+        otos.calibrateImu()
+    }
+
+    override fun getRobotYawPitchRollAngles(): YawPitchRollAngles {
+        return YawPitchRollAngles(AngleUnit.RADIANS, otos.position.h, 0.0, 0.0, 0L)
+    }
+
+    override fun getRobotOrientation(
+        p0: AxesReference?,
+        p1: AxesOrder?,
+        p2: AngleUnit?
+    ): Orientation {
+       throw NotImplementedError()
+    }
+
+    override fun getRobotOrientationAsQuaternion(): Quaternion {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRobotAngularVelocity(p0: AngleUnit?): AngularVelocity {
+        return AngularVelocity(AngleUnit.RADIANS, 0.0f, 0.0f, otos.velocity.h.toFloat(), 0L)
     }
 
 }

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -1,0 +1,26 @@
+package com.acmerobotics.roadrunner.ftc
+
+import com.qualcomm.hardware.sparkfun.SparkFunOTOS
+import com.qualcomm.hardware.sparkfun.SparkFunOTOS.Pose2D
+import com.qualcomm.robotcore.hardware.DcMotorSimple
+
+enum class EncoderDirection {
+    PARALLEL,
+    PERPENDICULAR
+}
+
+class OTOSEncoder(val otos: SparkFunOTOS, val ed: EncoderDirection) : Encoder {
+    override var direction = DcMotorSimple.Direction.FORWARD
+
+    override fun getPositionAndVelocity(): PositionVelocityPair {
+        val otosPose: Pose2D = Pose2D()
+        val otosVel: Pose2D = Pose2D()
+        otos.getPosVelAcc(otosPose, otosVel, Pose2D())
+
+        return when (ed) {
+            EncoderDirection.PARALLEL -> PositionVelocityPair(otosPose.x.toInt(), otosVel.x.toInt(), otosPose.x.toInt(), otosVel.x.toInt())
+            EncoderDirection.PERPENDICULAR -> PositionVelocityPair(otosPose.y.toInt(), otosVel.y.toInt(), otosPose.y.toInt(), otosVel.y.toInt())
+        }
+    }
+
+}

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -4,8 +4,10 @@ import com.acmerobotics.dashboard.FtcDashboard
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry
 import com.acmerobotics.roadrunner.MecanumKinematics
 import com.acmerobotics.roadrunner.MotorFeedforward
+import com.acmerobotics.roadrunner.Pose2d
 import com.acmerobotics.roadrunner.PoseVelocity2d
 import com.acmerobotics.roadrunner.PoseVelocity2dDual
+import com.acmerobotics.roadrunner.Rotation2d
 import com.acmerobotics.roadrunner.TankKinematics
 import com.acmerobotics.roadrunner.Time
 import com.acmerobotics.roadrunner.TimeProfile
@@ -13,6 +15,7 @@ import com.acmerobotics.roadrunner.Vector2d
 import com.acmerobotics.roadrunner.constantProfile
 import com.google.gson.annotations.SerializedName
 import com.qualcomm.hardware.lynx.LynxModule
+import com.qualcomm.hardware.sparkfun.SparkFunOTOS
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.hardware.DcMotor
 import com.qualcomm.robotcore.hardware.DcMotorEx
@@ -21,7 +24,9 @@ import com.qualcomm.robotcore.hardware.VoltageSensor
 import com.qualcomm.robotcore.util.ElapsedTime
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
+import kotlin.math.abs
 import kotlin.math.absoluteValue
+import kotlin.math.atan2
 import kotlin.math.max
 import kotlin.math.min
 
@@ -720,6 +725,81 @@ class DeadWheelDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() {
                 telemetry.addLine("  Wheel $i Position: ${view.encoder(view.perpEncs[i]).getPositionAndVelocity().position}")
             }
 
+            telemetry.update()
+        }
+    }
+}
+
+class OTOSAngularScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+    override fun runOpMode() {
+        var radsTurned = 0.0
+        telemetry.addLine("OTOS Angular Scalar Tuner")
+        telemetry.addLine("Press START, then rotate the robot on the ground 10 times (3600 degrees).")
+        telemetry.update()
+        waitForStart()
+        while (opModeIsActive()) {
+            val otosHeading = otos.position.h
+            radsTurned += otosHeading
+            telemetry.addData("OTOS Heading (radians)", otosHeading)
+            telemetry.addData("Uncorrected Degrees Turned", Math.toDegrees(radsTurned))
+            telemetry.addData("Calculated Angular Scalar", 3600 / Math.toDegrees(radsTurned))
+            telemetry.update()
+        }
+    }
+}
+
+class OTOSLinearScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+    override fun runOpMode() {
+        telemetry.addLine("OTOS Linear Scalar Tuner")
+        telemetry.addLine("Press START, then push the robot a known distance.")
+        telemetry.update()
+
+        waitForStart()
+
+        while (opModeIsActive()) {
+            val pose = otos.position
+            telemetry.addData("Uncorrected Distance Traveled Y", pose.x)
+            telemetry.addData("Uncorrected Distance Traveled X", pose.y)
+            telemetry.update()
+        }
+    }
+}
+
+class OTOSHeadingOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+    @Throws(InterruptedException::class)
+    override fun runOpMode() {
+        telemetry.addLine("OTOS Heading Offset Tuner")
+        telemetry.addLine("Line the side of the robot against a wall and Press START.")
+        telemetry.addLine("Then push the robot forward some distance.")
+        telemetry.update()
+        waitForStart()
+        while (opModeIsActive()) {
+            val pose = otos.position
+            telemetry.addData("Heading Offset (radians, enter this one into OTOSLocalizer!)", atan2(pose.y, pose.x))
+            telemetry.addData("Heading Offset (degrees)", Math.toDegrees(atan2(pose.y, pose.x)))
+            telemetry.update()
+        }
+    }
+}
+
+class OTOSPositionOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+    @Throws(InterruptedException::class)
+    override fun runOpMode() {
+        telemetry.addLine("OTOS Position Offset Tuner")
+        telemetry.addLine("Line the robot against the corner of two walls facing forward and Press START.")
+        telemetry.addLine("Then rotate the robot exactly 180 degrees and press it back into the corner.")
+        telemetry.addLine("Finally, copy the pose offset into OTOSLocalizer.")
+        telemetry.update()
+        waitForStart()
+        while (opModeIsActive()) {
+            val pose = otos.position
+            telemetry.addData("Heading (deg)", Math.toDegrees(pose.h))
+            if (abs(Math.toDegrees(pose.h)) > 175) {
+                telemetry.addData("X Offset", pose.x / 2)
+                telemetry.addData("Y Offset", pose.y / 2)
+            } else {
+                telemetry.addLine("Rotate the robot 180 degrees and align it to the corner again.")
+            }
             telemetry.update()
         }
     }

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -730,6 +730,7 @@ class DeadWheelDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() {
     }
 }
 
+/* Originally written by j5155; ported to Kotlin by zach.waffle */
 class OTOSAngularScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     override fun runOpMode() {
         var radsTurned = 0.0
@@ -765,6 +766,7 @@ class OTOSLinearScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     }
 }
 
+/* Originally written by j5155; ported to Kotlin by zach.waffle */
 class OTOSHeadingOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     @Throws(InterruptedException::class)
     override fun runOpMode() {
@@ -782,6 +784,7 @@ class OTOSHeadingOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     }
 }
 
+/* Originally written by j5155; ported to Kotlin by zach.waffle */
 class OTOSPositionOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     @Throws(InterruptedException::class)
     override fun runOpMode() {


### PR DESCRIPTION
This PR simply adds OpModes for tuning the scalars and offsets used by the SparkFun OTOS to the Tuning.kt file. It also adds a dependency on the FTC API Hardware module in order to access the OTOS driver from the SDK.