### PR TITLE
Give PinpointView Velocities

### DIFF
--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Encoders.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Encoders.kt
@@ -11,7 +11,7 @@ import kotlin.math.round
 class PositionVelocityPair(
         @JvmField val position: Int, @JvmField val velocity: Int?,
         @JvmField val rawPosition: Int, @JvmField val rawVelocity: Int?
- )
+ ) { constructor(position: Int, velocity: Int?) : this(position, velocity, position, velocity) }
 
 sealed interface Encoder {
     var direction: DcMotorSimple.Direction

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Encoders.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Encoders.kt
@@ -9,9 +9,9 @@ import kotlin.math.min
 import kotlin.math.round
 
 class PositionVelocityPair(
-        @JvmField val position: Int, @JvmField val velocity: Int?,
-        @JvmField val rawPosition: Int, @JvmField val rawVelocity: Int?
- ) { constructor(position: Int, velocity: Int?) : this(position, velocity, position, velocity) }
+        @JvmField val position: Int, @JvmField val velocity: Int,
+        @JvmField val rawPosition: Int, @JvmField val rawVelocity: Int
+ ) { constructor(position: Int, velocity: Int) : this(position, velocity, position, velocity) }
 
 sealed interface Encoder {
     var direction: DcMotorSimple.Direction
@@ -100,7 +100,7 @@ class OverflowEncoder(@JvmField val encoder: RawEncoder) : Encoder {
 
         return PositionVelocityPair(
                 p.position,
-                p.velocity?.let { inverseOverflow(it, v) },
+                inverseOverflow(p.velocity, v),
                 p.rawPosition,
                 p.rawVelocity,
         )

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -13,9 +13,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.Orientation
 import org.firstinspires.ftc.robotcore.external.navigation.Quaternion
 import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles
 import kotlin.math.round
-
-fun rawPosVelPair(pos: Int, vel: Int) = PositionVelocityPair(pos, vel, pos, vel)
-fun rawPosVelPair(pos: Double, vel: Double) = rawPosVelPair(round(pos).toInt(), round(vel).toInt())
+import kotlin.math.roundToInt
 
 fun SparkFunOTOS.Pose2D.toRRPose() = Pose2d(x, y, h)
 fun Pose2d.toOTOSPose() = SparkFunOTOS.Pose2D(position.x, position.y, heading.toDouble())
@@ -39,13 +37,13 @@ class OTOSEncoderGroup(val otos: SparkFunOTOS) : EncoderGroup {
 class ParallelOTOSEncoder(val group: OTOSEncoderGroup) : Encoder {
     override var direction = DcMotorSimple.Direction.FORWARD
 
-    override fun getPositionAndVelocity() = rawPosVelPair(group.pos.x, group.vel.x)
+    override fun getPositionAndVelocity() = PositionVelocityPair(group.pos.x.roundToInt(), group.vel.x.roundToInt())
 }
 
 class PerpendicularOTOSEncoder(val group: OTOSEncoderGroup) : Encoder {
     override var direction = DcMotorSimple.Direction.FORWARD
 
-    override fun getPositionAndVelocity() = rawPosVelPair(group.pos.y, group.vel.y)
+    override fun getPositionAndVelocity() = PositionVelocityPair(group.pos.y.roundToInt(), group.vel.y.roundToInt())
 }
 
 class OTOSIMU(val otos: SparkFunOTOS) : LazyImu, IMU, HardwareDevice by otos {

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Pinpoint.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Pinpoint.kt
@@ -16,6 +16,10 @@ interface PinpointView {
 
     fun getParEncoderPosition(): Int
     fun getPerpEncoderPosition(): Int
+
+    fun getParEncoderVelocity(): Int
+    fun getPerpEncoderVelocity(): Int
+
     fun getHeadingVelocity(): Float
 
     fun setParDirection(direction: DcMotorSimple.Direction)
@@ -28,9 +32,7 @@ class PinpointParEncoder(val pinpoint: PinpointView) : Encoder {
             field = value
             pinpoint.setParDirection(value)
         }
-    override fun getPositionAndVelocity() = pinpoint.getParEncoderPosition().let {
-        PositionVelocityPair(it, null, it, null)
-    }
+    override fun getPositionAndVelocity() = PositionVelocityPair(pinpoint.getParEncoderPosition(), pinpoint.getParEncoderVelocity())
 }
 
 class PinpointPerpEncoder(val pinpoint: PinpointView) : Encoder {
@@ -39,9 +41,7 @@ class PinpointPerpEncoder(val pinpoint: PinpointView) : Encoder {
             field = value
             pinpoint.setPerpDirection(value)
         }
-    override fun getPositionAndVelocity() = pinpoint.getPerpEncoderPosition().let {
-        PositionVelocityPair(it, null, it, null)
-    }
+    override fun getPositionAndVelocity() = PositionVelocityPair(pinpoint.getPerpEncoderPosition(), pinpoint.getPerpEncoderVelocity())
 }
 
 class PinpointEncoderGroup(

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Pinpoint.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Pinpoint.kt
@@ -12,6 +12,9 @@ import org.firstinspires.ftc.robotcore.external.navigation.Quaternion
 import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles
 
 interface PinpointView {
+    var parDirection: DcMotorSimple.Direction
+    var perpDirection: DcMotorSimple.Direction
+
     fun update()
 
     fun getParEncoderPosition(): Int
@@ -21,26 +24,25 @@ interface PinpointView {
     fun getPerpEncoderVelocity(): Int
 
     fun getHeadingVelocity(): Float
-
-    fun setParDirection(direction: DcMotorSimple.Direction)
-    fun setPerpDirection(direction: DcMotorSimple.Direction)
 }
 
 class PinpointParEncoder(val pinpoint: PinpointView) : Encoder {
-    override var direction = DcMotorSimple.Direction.FORWARD
+    override var direction = pinpoint.parDirection
         set(value) {
             field = value
-            pinpoint.setParDirection(value)
+            pinpoint.parDirection = value
         }
+
     override fun getPositionAndVelocity() = PositionVelocityPair(pinpoint.getParEncoderPosition(), pinpoint.getParEncoderVelocity())
 }
 
 class PinpointPerpEncoder(val pinpoint: PinpointView) : Encoder {
-    override var direction = DcMotorSimple.Direction.FORWARD
+    override var direction = pinpoint.perpDirection
         set(value) {
             field = value
-            pinpoint.setPerpDirection(value)
+            pinpoint.perpDirection = value
         }
+
     override fun getPositionAndVelocity() = PositionVelocityPair(pinpoint.getPerpEncoderPosition(), pinpoint.getPerpEncoderVelocity())
 }
 

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -178,10 +178,8 @@ private fun recordUnwrappedEncoderData(gs: List<EncoderGroup>, ts: List<Double>,
     ps.times.add(t)
     ps.values.add(pv.position.toDouble())
 
-    if (pv.velocity != null) {
-        vs.times.add(t)
-        vs.values.add(pv.velocity.toDouble())
-    }
+    vs.times.add(t)
+    vs.values.add(pv.velocity.toDouble())
 }
 
 class AngularRampLogger(val dvf: DriveViewFactory) : LinearOpMode() {


### PR DESCRIPTION
Since some of the tuning OpModes require velocities for the automatic tuning webpages to work, I added methods to get the velocities for both X and Y. I also changed the PinpointView setDirection functions to just be direction properties. There will be a corresponding PR for the quickstart to account for both of these additions.

