### PR TITLE
make otos tuning use dvf instead of an actual otos

### DIFF
--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/LazyImu.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/LazyImu.kt
@@ -5,6 +5,9 @@ import com.qualcomm.robotcore.hardware.IMU
 import com.qualcomm.robotcore.hardware.ImuOrientationOnRobot
 import com.qualcomm.robotcore.util.ElapsedTime
 import com.qualcomm.robotcore.util.RobotLog
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
 
 class ImuInitMessage(
         @JvmField
@@ -20,6 +23,8 @@ class ImuInitMessage(
 interface LazyImu {
     fun get(): IMU
 }
+
+fun normalizeAngle(angle: Double) = atan2(sin(angle), cos(angle))
 
 class LazyHardwareMapImu @JvmOverloads constructor(
         private val hardwareMap: HardwareMap,

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -66,7 +66,7 @@ class OTOSIMU(val otos: SparkFunOTOS) : LazyImu, IMU, HardwareDevice by otos {
     override fun getRobotOrientationAsQuaternion(): Quaternion = fail()
 
     override fun getRobotAngularVelocity(p0: AngleUnit?): AngularVelocity {
-        return AngularVelocity(AngleUnit.RADIANS, 0.0f, 0.0f, otos.velocity.h.toFloat(), 0L)
+        return AngularVelocity(otos.angularUnit, 0.0f, 0.0f, otos.velocity.h.toFloat(), 0L)
     }
 
     override fun get() = this as IMU

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/OTOS.kt
@@ -54,7 +54,7 @@ class OTOSIMU(val otos: SparkFunOTOS) : LazyImu, IMU, HardwareDevice by otos {
     override fun resetYaw() = fail()
 
     override fun getRobotYawPitchRollAngles(): YawPitchRollAngles {
-        return YawPitchRollAngles(AngleUnit.RADIANS, otos.position.h, 0.0, 0.0, 0L)
+        return YawPitchRollAngles(otos.angularUnit, normalizeAngle(otos.position.h), 0.0, 0.0, 0L)
     }
 
     override fun getRobotOrientation(

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -740,12 +740,19 @@ class DeadWheelDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() {
     }
 }
 
+const val OTOS_ERROR_MSG =
+    """
+    Only run this OpMode if you are using a Sparkfun OTOS.
+    This OpMode requires OTOS to be properly configured. 
+    See Tuning docs for details.
+    """
+
 /* Originally written by j5155; ported to Kotlin by zach.waffle */
 class OTOSAngularScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
         val view = dvf.make(hardwareMap)
 
-        require(view.imu is OTOSIMU) { "make sure to set the IMU to an OTOSIMU" }
+        require(view.imu is OTOSIMU) { OTOS_ERROR_MSG }
 
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
@@ -773,7 +780,7 @@ class OTOSLinearScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
         val view = dvf.make(hardwareMap)
 
-        require(view.encoderGroups.first() is OTOSEncoderGroup)
+        require(view.encoderGroups.first() is OTOSEncoderGroup) { OTOS_ERROR_MSG }
 
         val parallelEnc = view.encoderGroups.first().encoders.first()
         val perpEnc = view.encoderGroups.first().encoders.last()
@@ -803,7 +810,7 @@ class OTOSHeadingOffsetTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
         val view = dvf.make(hardwareMap)
 
-        require(view.encoderGroups.first() is OTOSEncoderGroup)
+        require(view.encoderGroups.first() is OTOSEncoderGroup) { OTOS_ERROR_MSG }
 
         val parallelEnc = view.encoderGroups.first().encoders.first()
         val perpEnc = view.encoderGroups.first().encoders.last()
@@ -833,8 +840,8 @@ class OTOSPositionOffsetTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
         val view = dvf.make(hardwareMap)
 
-        require(view.imu is OTOSIMU) { "make sure to set the IMU to an OTOSIMU" }
-        require(view.encoderGroups.first() is OTOSEncoderGroup)
+        require(view.imu is OTOSIMU) { OTOS_ERROR_MSG }
+        require(view.encoderGroups.first() is OTOSEncoderGroup) { OTOS_ERROR_MSG }
 
         val parallelEnc = view.encoderGroups.first().encoders.first()
         val perpEnc = view.encoderGroups.first().encoders.last()

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -741,18 +741,26 @@ class DeadWheelDirectionDebugger(val dvf: DriveViewFactory) : LinearOpMode() {
 }
 
 /* Originally written by j5155; ported to Kotlin by zach.waffle */
-class OTOSAngularScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+class OTOSAngularScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
+        val view = dvf.make(hardwareMap)
+
+        require(view.imu is OTOSIMU) { "make sure to set the IMU to an OTOSIMU" }
+
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         var radsTurned = 0.0
+        var lastHeading = 0.0
+
         telemetry.addLine("OTOS Angular Scalar Tuner")
         telemetry.addLine("Press START, then rotate the robot on the ground 10 times (3600 degrees).")
         telemetry.update()
         waitForStart()
         while (opModeIsActive()) {
-            val otosHeading = otos.position.h
-            radsTurned += otosHeading
+            val otosHeading = view.imu.get().robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
+
+            radsTurned += (otosHeading - lastHeading)
+
             telemetry.addData("OTOS Heading (radians)", otosHeading)
             telemetry.addData("Uncorrected Degrees Turned", Math.toDegrees(radsTurned))
             telemetry.addData("Calculated Angular Scalar", 3600 / Math.toDegrees(radsTurned))
@@ -761,8 +769,15 @@ class OTOSAngularScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
     }
 }
 
-class OTOSLinearScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+class OTOSLinearScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     override fun runOpMode() {
+        val view = dvf.make(hardwareMap)
+
+        require(view.encoderGroups.first() is OTOSEncoderGroup)
+
+        val parallelEnc = view.encoderGroups.first().encoders.first()
+        val perpEnc = view.encoderGroups.first().encoders.last()
+
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         telemetry.addLine("OTOS Linear Scalar Tuner")
@@ -772,38 +787,58 @@ class OTOSLinearScalarTuner(val otos: SparkFunOTOS) : LinearOpMode() {
         waitForStart()
 
         while (opModeIsActive()) {
-            val pose = otos.position
-            telemetry.addData("Uncorrected Distance Traveled Y", pose.x)
-            telemetry.addData("Uncorrected Distance Traveled X", pose.y)
+            val xPos = parallelEnc.getPositionAndVelocity().position * view.inPerTick
+            val yPos = perpEnc.getPositionAndVelocity().position * view.inPerTick
+
+            telemetry.addData("Uncorrected Distance Traveled Y", xPos)
+            telemetry.addData("Uncorrected Distance Traveled X", yPos)
             telemetry.update()
         }
     }
 }
 
 /* Originally written by j5155; ported to Kotlin by zach.waffle */
-class OTOSHeadingOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+class OTOSHeadingOffsetTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     @Throws(InterruptedException::class)
     override fun runOpMode() {
+        val view = dvf.make(hardwareMap)
+
+        require(view.encoderGroups.first() is OTOSEncoderGroup)
+
+        val parallelEnc = view.encoderGroups.first().encoders.first()
+        val perpEnc = view.encoderGroups.first().encoders.last()
+
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         telemetry.addLine("OTOS Heading Offset Tuner")
         telemetry.addLine("Line the side of the robot against a wall and Press START.")
         telemetry.addLine("Then push the robot forward some distance.")
         telemetry.update()
+
         waitForStart()
         while (opModeIsActive()) {
-            val pose = otos.position
-            telemetry.addData("Heading Offset (radians, enter this one into OTOSLocalizer!)", atan2(pose.y, pose.x))
-            telemetry.addData("Heading Offset (degrees)", Math.toDegrees(atan2(pose.y, pose.x)))
+            val xPos = parallelEnc.getPositionAndVelocity().position * view.inPerTick
+            val yPos = perpEnc.getPositionAndVelocity().position * view.inPerTick
+
+            telemetry.addData("Heading Offset (radians, enter this one into OTOSLocalizer!)", atan2(yPos, xPos))
+            telemetry.addData("Heading Offset (degrees)", Math.toDegrees(atan2(yPos, xPos)))
             telemetry.update()
         }
     }
 }
 
 /* Originally written by j5155; ported to Kotlin by zach.waffle */
-class OTOSPositionOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
+class OTOSPositionOffsetTuner(val dvf: DriveViewFactory) : LinearOpMode() {
     @Throws(InterruptedException::class)
     override fun runOpMode() {
+        val view = dvf.make(hardwareMap)
+
+        require(view.imu is OTOSIMU) { "make sure to set the IMU to an OTOSIMU" }
+        require(view.encoderGroups.first() is OTOSEncoderGroup)
+
+        val parallelEnc = view.encoderGroups.first().encoders.first()
+        val perpEnc = view.encoderGroups.first().encoders.last()
+
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         telemetry.addLine("OTOS Position Offset Tuner")
@@ -813,11 +848,14 @@ class OTOSPositionOffsetTuner(val otos: SparkFunOTOS) : LinearOpMode() {
         telemetry.update()
         waitForStart()
         while (opModeIsActive()) {
-            val pose = otos.position
-            telemetry.addData("Heading (deg)", Math.toDegrees(pose.h))
-            if (abs(Math.toDegrees(pose.h)) > 175) {
-                telemetry.addData("X Offset", pose.x / 2)
-                telemetry.addData("Y Offset", pose.y / 2)
+            val heading = view.imu.get().robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
+            val xPos = parallelEnc.getPositionAndVelocity().position * view.inPerTick
+            val yPos = perpEnc.getPositionAndVelocity().position * view.inPerTick
+
+            telemetry.addData("Heading (deg)", Math.toDegrees(heading))
+            if (abs(Math.toDegrees(heading)) > 175) {
+                telemetry.addData("X Offset", xPos / 2)
+                telemetry.addData("Y Offset", yPos / 2)
             } else {
                 telemetry.addLine("Rotate the robot 180 degrees and align it to the corner again.")
             }

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -6,6 +6,7 @@ import com.acmerobotics.roadrunner.MecanumKinematics
 import com.acmerobotics.roadrunner.MotorFeedforward
 import com.acmerobotics.roadrunner.PoseVelocity2d
 import com.acmerobotics.roadrunner.PoseVelocity2dDual
+import com.acmerobotics.roadrunner.Rotation2d
 import com.acmerobotics.roadrunner.TankKinematics
 import com.acmerobotics.roadrunner.Time
 import com.acmerobotics.roadrunner.TimeProfile
@@ -767,7 +768,7 @@ class OTOSAngularScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
         while (opModeIsActive()) {
             val otosHeading = imu.robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
 
-            radsTurned += (otosHeading - lastHeading)
+            radsTurned += (Rotation2d.exp(otosHeading) - Rotation2d.exp(lastHeading))
             lastHeading = otosHeading
 
             telemetry.addData("OTOS Heading (radians)", otosHeading)

--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -754,19 +754,21 @@ class OTOSAngularScalarTuner(val dvf: DriveViewFactory) : LinearOpMode() {
 
         require(view.imu is OTOSIMU) { OTOS_ERROR_MSG }
 
+        val imu = view.imu.get()
         telemetry = MultipleTelemetry(telemetry, FtcDashboard.getInstance().telemetry)
 
         var radsTurned = 0.0
-        var lastHeading = 0.0
+        var lastHeading = imu.robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
 
         telemetry.addLine("OTOS Angular Scalar Tuner")
         telemetry.addLine("Press START, then rotate the robot on the ground 10 times (3600 degrees).")
         telemetry.update()
         waitForStart()
         while (opModeIsActive()) {
-            val otosHeading = view.imu.get().robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
+            val otosHeading = imu.robotYawPitchRollAngles.getYaw(AngleUnit.RADIANS)
 
             radsTurned += (otosHeading - lastHeading)
+            lastHeading = otosHeading
 
             telemetry.addData("OTOS Heading (radians)", otosHeading)
             telemetry.addData("Uncorrected Degrees Turned", Math.toDegrees(radsTurned))


### PR DESCRIPTION
this satisfies [acmerobotics/road-runner-quickstart/#489](https://github.com/acmerobotics/road-runner-ftc/compare/master...zachwaffle4:otos?expand=1); the tuners no longer need an actual otos and can just get their information from the drive view's imu and encoders