### PR TITLE
Switch to plotly.js-basic-dist-min, reducing disk size by 66%

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "vite": "^4.4.9"
   },
   "dependencies": {
-    "plotly.js-dist-min": "2.3.1",
+    "plotly.js-basic-dist-min": "2.3.1",
     "regression": "^2.0.1"
   }
 }

--- a/web/tuning/common.ts
+++ b/web/tuning/common.ts
@@ -1,4 +1,4 @@
-import Plotly from 'plotly.js-dist-min';
+import Plotly from 'plotly.js-basic-dist-min';
 import regression, { DataPoint } from 'regression';
 
 // TODO: time-interpolate data

--- a/web/tuning/test/overflow.html
+++ b/web/tuning/test/overflow.html
@@ -26,78 +26,78 @@ fieldset {
     </style>
 
     <script type="module">
-import Plotly from "plotly.js-dist-min";
-import {numDerivOffline, numDerivOnline, inverseOverflow} from '../common.ts';
+        import Plotly from "plotly.js-basic-dist-min";
+        import {numDerivOffline, numDerivOnline, inverseOverflow} from '../common.ts';
 
-function newChart(container, xs, ys, options) {
-  if (xs.length !== ys.length) {
-    throw new Error();
-  }
+        function newChart(container, xs, ys, options) {
+          if (xs.length !== ys.length) {
+            throw new Error();
+          }
 
-  // cribbed from https://plotly.com/javascript/plotlyjs-events/#select-event
-  const color = '#777';
-  const colorLight = '#bbb';
+          // cribbed from https://plotly.com/javascript/plotlyjs-events/#select-event
+          const color = '#777';
+          const colorLight = '#bbb';
 
-  const chartDiv = document.createElement('div');
-  Plotly.newPlot(chartDiv, [{
-    type: 'scatter',
-    mode: 'markers',
-    x: xs,
-    y: ys,
-    name: 'Samples',
-  }], {
-    title: options.title || '',
-    // sets the starting tool from the modebar
-    dragmode: 'zoom',
-    showlegend: false,
-    hovermode: false,
-    width: 600,
-  }, {
-    // 'zoom2d', 'select2d', 'resetScale2d' left
-    modeBarButtonsToRemove: ['pan2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
-  });
+          const chartDiv = document.createElement('div');
+          Plotly.newPlot(chartDiv, [{
+            type: 'scatter',
+            mode: 'markers',
+            x: xs,
+            y: ys,
+            name: 'Samples',
+          }], {
+            title: options.title || '',
+            // sets the starting tool from the modebar
+            dragmode: 'zoom',
+            showlegend: false,
+            hovermode: false,
+            width: 600,
+          }, {
+            // 'zoom2d', 'select2d', 'resetScale2d' left
+            modeBarButtonsToRemove: ['pan2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
+          });
 
-  container.appendChild(chartDiv);
-}
+          container.appendChild(chartDiv);
+        }
 
-window.addEventListener("DOMContentLoaded", function() {
-  const params = new URLSearchParams(window.location.search);
-  const online = params.get('online') === 'true';
+        window.addEventListener("DOMContentLoaded", function() {
+          const params = new URLSearchParams(window.location.search);
+          const online = params.get('online') === 'true';
 
-  fetch(`/tuning/test/${params.get('file')}.csv`)
-    .then(res => res.text())
-    .then(text => {
-      const lines = text.split('\n');
-      const data = lines
-        .slice(1, lines.length - 1)
-        .map(line => line.split(',').map(x => parseFloat(x)))
-      
-      const xs = data.map(xs => xs[0]);
-      const vs = data.map(xs => xs[1]);
-      const ts = data.map(xs => xs[2]);
+          fetch(`/tuning/test/${params.get('file')}.csv`)
+            .then(res => res.text())
+            .then(text => {
+              const lines = text.split('\n');
+              const data = lines
+                .slice(1, lines.length - 1)
+                .map(line => line.split(',').map(x => parseFloat(x)))
 
-      const container = document.getElementById('content');
-      newChart(container, ts, vs, {title: 'Raw Velocity Over Time'});
+              const xs = data.map(xs => xs[0]);
+              const vs = data.map(xs => xs[1]);
+              const ts = data.map(xs => xs[2]);
 
-      const tsNew = (online ? ts.slice(1) : ts.slice(1, ts.length - 1));
-      const dxdts = (online ? numDerivOnline : numDerivOffline)(ts, xs);
-      newChart(
-        container, 
-        tsNew,
-        dxdts, 
-        {title: `${online ? 'Online' : 'Offline'} Position Derivative Over Time`}
-      );
+              const container = document.getElementById('content');
+              newChart(container, ts, vs, {title: 'Raw Velocity Over Time'});
 
-      const vsNew = dxdts.map((est, i) => inverseOverflow(vs[i + 1], est));
-      newChart(
-        container, 
-        tsNew,
-        vsNew, 
-        {title: 'Corrected Velocity Over Time'}
-      );
-    })
-    .catch(console.log.bind(console));
-});
+              const tsNew = (online ? ts.slice(1) : ts.slice(1, ts.length - 1));
+              const dxdts = (online ? numDerivOnline : numDerivOffline)(ts, xs);
+              newChart(
+                container,
+                tsNew,
+                dxdts,
+                {title: `${online ? 'Online' : 'Offline'} Position Derivative Over Time`}
+              );
+
+              const vsNew = dxdts.map((est, i) => inverseOverflow(vs[i + 1], est));
+              newChart(
+                container,
+                tsNew,
+                vsNew,
+                {title: 'Corrected Velocity Over Time'}
+              );
+            })
+            .catch(console.log.bind(console));
+        });
 
     </script>
   </head>

--- a/web/tuning/test/overflow.html
+++ b/web/tuning/test/overflow.html
@@ -26,78 +26,78 @@ fieldset {
     </style>
 
     <script type="module">
-        import Plotly from "plotly.js-basic-dist-min";
-        import {numDerivOffline, numDerivOnline, inverseOverflow} from '../common.ts';
+import Plotly from "plotly.js-basic-dist-min";
+import {numDerivOffline, numDerivOnline, inverseOverflow} from '../common.ts';
 
-        function newChart(container, xs, ys, options) {
-          if (xs.length !== ys.length) {
-            throw new Error();
-          }
+function newChart(container, xs, ys, options) {
+  if (xs.length !== ys.length) {
+    throw new Error();
+  }
 
-          // cribbed from https://plotly.com/javascript/plotlyjs-events/#select-event
-          const color = '#777';
-          const colorLight = '#bbb';
+  // cribbed from https://plotly.com/javascript/plotlyjs-events/#select-event
+  const color = '#777';
+  const colorLight = '#bbb';
 
-          const chartDiv = document.createElement('div');
-          Plotly.newPlot(chartDiv, [{
-            type: 'scatter',
-            mode: 'markers',
-            x: xs,
-            y: ys,
-            name: 'Samples',
-          }], {
-            title: options.title || '',
-            // sets the starting tool from the modebar
-            dragmode: 'zoom',
-            showlegend: false,
-            hovermode: false,
-            width: 600,
-          }, {
-            // 'zoom2d', 'select2d', 'resetScale2d' left
-            modeBarButtonsToRemove: ['pan2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
-          });
+  const chartDiv = document.createElement('div');
+  Plotly.newPlot(chartDiv, [{
+    type: 'scatter',
+    mode: 'markers',
+    x: xs,
+    y: ys,
+    name: 'Samples',
+  }], {
+    title: options.title || '',
+    // sets the starting tool from the modebar
+    dragmode: 'zoom',
+    showlegend: false,
+    hovermode: false,
+    width: 600,
+  }, {
+    // 'zoom2d', 'select2d', 'resetScale2d' left
+    modeBarButtonsToRemove: ['pan2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
+  });
 
-          container.appendChild(chartDiv);
-        }
+  container.appendChild(chartDiv);
+}
 
-        window.addEventListener("DOMContentLoaded", function() {
-          const params = new URLSearchParams(window.location.search);
-          const online = params.get('online') === 'true';
+window.addEventListener("DOMContentLoaded", function() {
+  const params = new URLSearchParams(window.location.search);
+  const online = params.get('online') === 'true';
 
-          fetch(`/tuning/test/${params.get('file')}.csv`)
-            .then(res => res.text())
-            .then(text => {
-              const lines = text.split('\n');
-              const data = lines
-                .slice(1, lines.length - 1)
-                .map(line => line.split(',').map(x => parseFloat(x)))
+  fetch(`/tuning/test/${params.get('file')}.csv`)
+    .then(res => res.text())
+    .then(text => {
+      const lines = text.split('\n');
+      const data = lines
+        .slice(1, lines.length - 1)
+        .map(line => line.split(',').map(x => parseFloat(x)))
 
-              const xs = data.map(xs => xs[0]);
-              const vs = data.map(xs => xs[1]);
-              const ts = data.map(xs => xs[2]);
+      const xs = data.map(xs => xs[0]);
+      const vs = data.map(xs => xs[1]);
+      const ts = data.map(xs => xs[2]);
 
-              const container = document.getElementById('content');
-              newChart(container, ts, vs, {title: 'Raw Velocity Over Time'});
+      const container = document.getElementById('content');
+      newChart(container, ts, vs, {title: 'Raw Velocity Over Time'});
 
-              const tsNew = (online ? ts.slice(1) : ts.slice(1, ts.length - 1));
-              const dxdts = (online ? numDerivOnline : numDerivOffline)(ts, xs);
-              newChart(
-                container,
-                tsNew,
-                dxdts,
-                {title: `${online ? 'Online' : 'Offline'} Position Derivative Over Time`}
-              );
+      const tsNew = (online ? ts.slice(1) : ts.slice(1, ts.length - 1));
+      const dxdts = (online ? numDerivOnline : numDerivOffline)(ts, xs);
+      newChart(
+        container,
+        tsNew,
+        dxdts,
+        {title: `${online ? 'Online' : 'Offline'} Position Derivative Over Time`}
+      );
 
-              const vsNew = dxdts.map((est, i) => inverseOverflow(vs[i + 1], est));
-              newChart(
-                container,
-                tsNew,
-                vsNew,
-                {title: 'Corrected Velocity Over Time'}
-              );
-            })
-            .catch(console.log.bind(console));
-        });
+      const vsNew = dxdts.map((est, i) => inverseOverflow(vs[i + 1], est));
+      newChart(
+        container,
+        tsNew,
+        vsNew,
+        {title: 'Corrected Velocity Over Time'}
+      );
+    })
+    .catch(console.log.bind(console));
+});
 
     </script>
   </head>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -179,10 +179,10 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-plotly.js-dist-min@2.3.1:
+plotly.js-basic-dist-min@2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/plotly.js-dist-min/-/plotly.js-dist-min-2.3.1.tgz#b8ddd7ddd3abf4ec06b7686d493d07c564de2241"
-  integrity sha512-Y5srb2izG/TO3KcWb2soAL6IP5/KZ3VS+hIr8skUgCVqtAK9CYzxjNS1fIzn4Y6OdcxoK3dbjqqPjmESOQga2g==
+  resolved "https://registry.yarnpkg.com/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.3.1.tgz#76b27c5fe6096a2831f164bf4c5b85d59e7774c8"
+  integrity sha512-HkCGj2bisy4KrXA5NhdkVWpEZUejIRrLKhOfraWBYUbRzGJEoCq/9fIUS5oEYLVN8dT3qYkULAsa9Umjzeg/Ww==
 
 postcss@^8.4.27:
   version "8.4.28"


### PR DESCRIPTION
This PR switches the bundle of plotly.js to [basic](https://github.com/plotly/plotly.js/blob/master/dist/README.md#plotlyjs-basic). As roadrunner tuning pages only use the scatter plots, the other plots available in the full distribution are unhelpful and single-handedly triple the size of the library. 

This patch brings the file size of the built library from 1.2 MB to 0.5 MB. This means less network usage in each download and less disk space taken up by the library, as well as making it a lot easier to publish forks; some hosting servers refuse to serve files larger than 1 MB.


