### PR TITLE
Fix to Unreasonable large v0 value in ManualFeedforwardTuner when using Pinpoint

### DIFF
--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -571,8 +571,9 @@ class ManualFeedforwardTuner(val dvf: DriveViewFactory) : LinearOpMode() {
                         val v = if (pv.velocity == null) {
                             val lastPos = lastPositions[i]
                             lastPositions[i] = pv.position
+                            val currVelocity = velEstimates[i].update((pv.position - lastPos) / lastTimes[i].seconds())
                             lastTimes[i].reset()
-                            velEstimates[i].update((pv.position - lastPos) / lastTimes[i].seconds())
+                            currVelocity
                         } else {
                             pv.velocity.toDouble()
                         }


### PR DESCRIPTION
Lines 571-576 in Tuning.kt:

Original Code:
val v = if (pv.velocity == null) {
                            val lastPos = lastPositions[i]
                            lastPositions[i] = pv.position
                            lastTimes[i].reset()
                            velEstimates[i].update((pv.position - lastPos) / lastTimes[i].seconds())
                        }

Previously, the ElapsedTime() object in lastTimes[i] was reset on the line right before it was used to calculate velocity as lastTimes[i].seconds(), resulting in velocity being calculated as the difference in positions divided by the time between the execution of the two lines (a very small value). 

New Code:
val v = if (pv.velocity == null) {
                            val lastPos = lastPositions[i]
                            lastPositions[i] = pv.position
                            val currVelocity = velEstimates[i].update((pv.position - lastPos) / lastTimes[i].seconds())
                            lastTimes[i].reset()
                            currVelocity
                        }

Now, the velocity is first calculated before lastTimes[i].reset() is called and stored in a temporary variable before the ElapsedTime() object is reset. This way, it calculates velocity with the loop time between when the position was last taken and this loop. Then, lastTimes[i].reset() is called to set the current time as the last time for the next loop, and v is set to currVelocity.

