### PR TITLE
ManualFeedforwardTuner lateral input crash fix for TankDrive

### DIFF
--- a/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
+++ b/RoadRunner/src/main/java/com/acmerobotics/roadrunner/ftc/Tuning.kt
@@ -607,7 +607,7 @@ class ManualFeedforwardTuner(val dvf: DriveViewFactory) : LinearOpMode() {
                     view.setDrivePowers(PoseVelocity2d(
                             Vector2d(
                                     -gamepad1.left_stick_y.toDouble(),
-                                    -gamepad1.left_stick_x.toDouble()
+                                    if (view.type == DriveType.TANK) 0.0 else -gamepad1.left_stick_x.toDouble()
                             ),
                             -gamepad1.right_stick_x.toDouble()
                     ))


### PR DESCRIPTION
Hi,

We found with our use of the `ManualFeedforwardTuner` tuning OpMode using a TankDrive instance, if any lateral input is inputted with the controller, it would immediately crash the OpMode as the requirement corresponding with `Tank drive does not support lateral motion` fires:
https://github.com/acmerobotics/road-runner/blob/b5b52db26390aa437efa1cc91069f7b8b5b4f3d0/road-runner/core/src/main/kotlin/com/acmerobotics/roadrunner/Kinematics.kt#L108

However this means any accidental input along the stick's x-axis will cause the tuning OpMode to crash. This PR checks in tuning if the instance is a tank drive to send zero power to the strafe component in driver control. A similar pattern is present in the quickstart for `LocalizationTest` to prevent crashing and should be implemented here too.